### PR TITLE
fix esphome upgrade to also upgrade platformio

### DIFF
--- a/overlay/usr/local/etc/rc.d/esphome
+++ b/overlay/usr/local/etc/rc.d/esphome
@@ -70,8 +70,11 @@ esphome_upgrade() {
     su ${esphome_user} -c '
       source ${1}/bin/activate || exit 1
       pip3 install --upgrade esphome
+      export PLATFORMIO_CORE_DIR="${2}/.platformio"
+      platformio upgrade
+      platformio update
       deactivate
-    ' _ ${esphome_venv} || exit 1
+    ' _ ${esphome_venv} ${esphome_config_dir} || exit 1
     [ $? == 0 ] && service ${name} start
 }
 


### PR DESCRIPTION
Now it upgrades platformio core, boards and libs.
After changes output looks like this:
```
1) Main Menu
2) status
3) restart
4) upgrade
5) start
6) stop
7) test
8) remove

Select: 4
Stopping esphome.
Requirement already up-to-date: esphome in /srv/esphome/lib/python3.7/site-packages (1.14.3)
Requirement already satisfied, skipping upgrade: tornado==5.1.1 in /srv/esphome/lib/python3.7/site-packages (from esphome) (5.1.1)
Requirement already satisfied, skipping upgrade: protobuf==3.10.0 in /srv/esphome/lib/python3.7/site-packages (from esphome) (3.10.0)
Requirement already satisfied, skipping upgrade: colorlog==4.0.2 in /srv/esphome/lib/python3.7/site-packages (from esphome) (4.0.2)
Requirement already satisfied, skipping upgrade: paho-mqtt==1.4.0 in /srv/esphome/lib/python3.7/site-packages (from esphome) (1.4.0)
Requirement already satisfied, skipping upgrade: ifaddr==0.1.6 in /srv/esphome/lib/python3.7/site-packages (from esphome) (0.1.6)
Requirement already satisfied, skipping upgrade: PyYAML==5.1.2 in /srv/esphome/lib/python3.7/site-packages (from esphome) (5.1.2)
Requirement already satisfied, skipping upgrade: tzlocal==2.0.0 in /srv/esphome/lib/python3.7/site-packages (from esphome) (2.0.0)
Requirement already satisfied, skipping upgrade: voluptuous==0.11.7 in /srv/esphome/lib/python3.7/site-packages (from esphome) (0.11.7)
Requirement already satisfied, skipping upgrade: esptool==2.7 in /srv/esphome/lib/python3.7/site-packages (from esphome) (2.7)
Requirement already satisfied, skipping upgrade: pytz==2019.3 in /srv/esphome/lib/python3.7/site-packages (from esphome) (2019.3)
Requirement already satisfied, skipping upgrade: pyserial==3.4 in /srv/esphome/lib/python3.7/site-packages (from esphome) (3.4)
Collecting platformio==4.0.3
  Using cached https://files.pythonhosted.org/packages/5d/59/2ba54e3f2ae8435997acbd0d0ff31993a7041a8b11515e0b5cc846a71ca4/platformio-4.0.3.tar.gz
Requirement already satisfied, skipping upgrade: six>=1.9 in /srv/esphome/lib/python3.7/site-packages (from protobuf==3.10.0->esphome) (1.14.0)
Requirement already satisfied, skipping upgrade: setuptools in /srv/esphome/lib/python3.7/site-packages (from protobuf==3.10.0->esphome) (41.2.0)
Requirement already satisfied, skipping upgrade: pyaes in /srv/esphome/lib/python3.7/site-packages (from esptool==2.7->esphome) (1.6.1)
Requirement already satisfied, skipping upgrade: ecdsa in /srv/esphome/lib/python3.7/site-packages (from esptool==2.7->esphome) (0.15)
Requirement already satisfied, skipping upgrade: bottle<0.13 in /srv/esphome/lib/python3.7/site-packages (from platformio==4.0.3->esphome) (0.12.18)
Requirement already satisfied, skipping upgrade: click<8,>=5 in /srv/esphome/lib/python3.7/site-packages (from platformio==4.0.3->esphome) (7.0)
Requirement already satisfied, skipping upgrade: colorama in /srv/esphome/lib/python3.7/site-packages (from platformio==4.0.3->esphome) (0.4.3)
Requirement already satisfied, skipping upgrade: requests<3,>=2.4.0 in /srv/esphome/lib/python3.7/site-packages (from platformio==4.0.3->esphome) (2.22.0)
Requirement already satisfied, skipping upgrade: semantic_version<3,>=2.8.1 in /srv/esphome/lib/python3.7/site-packages (from platformio==4.0.3->esphome) (2.8.4)
Requirement already satisfied, skipping upgrade: tabulate<1,>=0.8.3 in /srv/esphome/lib/python3.7/site-packages (from platformio==4.0.3->esphome) (0.8.6)
Requirement already satisfied, skipping upgrade: chardet<3.1.0,>=3.0.2 in /srv/esphome/lib/python3.7/site-packages (from requests<3,>=2.4.0->platformio==4.0.3->esphome) (3.0.4)
Requirement already satisfied, skipping upgrade: certifi>=2017.4.17 in /srv/esphome/lib/python3.7/site-packages (from requests<3,>=2.4.0->platformio==4.0.3->esphome) (2019.11.28)
Requirement already satisfied, skipping upgrade: urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 in /srv/esphome/lib/python3.7/site-packages (from requests<3,>=2.4.0->platformio==4.0.3->esphome) (1.25.7)
Requirement already satisfied, skipping upgrade: idna<2.9,>=2.5 in /srv/esphome/lib/python3.7/site-packages (from requests<3,>=2.4.0->platformio==4.0.3->esphome) (2.8)
Installing collected packages: platformio
  Found existing installation: platformio 4.1.0
    Uninstalling platformio-4.1.0:
      Successfully uninstalled platformio-4.1.0
    Running setup.py install for platformio ... done
Successfully installed platformio-4.0.3
Please wait while upgrading PlatformIO ...
PlatformIO has been successfully upgraded to 4.1.0
Release notes: https://docs.platformio.org/en/latest/history.html
Updating tool-scons                      @ 3.30101.0      [Up-to-date]

Platform Manager
================
Platform Espressif 32
--------
Updating espressif32                     @ 1.11.1         [Up-to-date]
Updating toolchain-xtensa32              @ 2.50200.80     [Detached]
Updating framework-arduinoespressif32    @ 2.10004.191002 [Up-to-date]
Updating tool-esptoolpy                  @ 1.20600.0      [Up-to-date]


Library Manager
===============
Library Storage: /home/hass/esphome/.platformio/lib
Starting esphome.

Press ENTER to continue...
```